### PR TITLE
Improve transitions between images

### DIFF
--- a/src/components/style.css
+++ b/src/components/style.css
@@ -232,3 +232,11 @@ img.vue-lb-modal-image {
   }
 }
 
+.fade-enter-active, 
+.fade-leave-active {
+  transition: opacity .3s ease;
+}
+
+.fade-enter, .fade-leave-to {
+  opacity: 0;
+}

--- a/src/components/template.html
+++ b/src/components/template.html
@@ -63,7 +63,7 @@
 
     <div 
       v-for="(image, index) in imagesThumb" 
-      :key="image.src + index"
+      :key="index"
       :class="'vue-lb-modal-thumbnail' + (thumbSelect === index ? '-active' : '')" 
       v-lazy:background-image="image"
       @click="showImage(index + beginThumbIndex)"

--- a/src/components/template.html
+++ b/src/components/template.html
@@ -26,10 +26,13 @@
 
     </div> <!-- .vue-lb-header -->
     <div class="vue-lb-figure">
-      <img 
-        v-lazy="imagesSrc[select]"
-        class="vue-lb-modal-image"
-      >
+       <transition mode="out-in" name="fade">
+           <img 
+             :key="imagesSrc[select].src"
+             :src="imagesSrc[select].src"
+             class="vue-lb-modal-image"
+           >
+       </transition>
 
       <div 
         class="vue-lb-info" 
@@ -109,5 +112,4 @@
       </svg>
     </span>
   </button>
-</div> <!-- .vue-lb-container -->
-    
+</div> <!-- .vue-lb-container -->    


### PR DESCRIPTION
These changes allow us to use a fade transition when navigating between images and prevents repainting the thumbnails when doing so:
![Example of fade transition](http://g.recordit.co/7NvHE4dkIg.gif)