### PR TITLE
Add video autoplay option, fix playback time discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ How to use:
     caption: '<h4>Monsters Inc.</h4>',
     width: 800, // required
     height: 600, // required
+    autoplay: true //Optional to autoplay video when lightbox opens
   }
 ]
 ```

--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -42,6 +42,7 @@
               controls
               :width="media[select].width"
               :height="media[select].height"
+              :autoplay="media[select].autoplay"
             >
               <source
                 v-for="source in media[select].sources"
@@ -365,7 +366,9 @@ export default {
       }
 
       if (value) {
-        document.querySelector('body').classList.add('vue-lb-open')
+				document.querySelector('body').classList.add('vue-lb-open')
+				if (this.$refs.video && this.$refs.video.autoplay)
+            this.$refs.video.play()
       } else {
         document.querySelector('body').classList.remove('vue-lb-open')
       }
@@ -391,8 +394,10 @@ export default {
     },
 
     closeLightBox() {
-      if (this.$refs.video)
-        this.$refs.video.pause();
+      if (this.$refs.video) {
+        this.$refs.video.pause()
+        this.$refs.video.currentTime = '0'
+      }
       if (!this.closable) return;
       this.$set(this, 'lightBoxOn', false)
     },


### PR DESCRIPTION
1. Video wasn't starting at 0 when the lightbox was closed and reopened. Fixed it to match behavior on clicking prev, next. 
2. Added option to autoplay video on lightbox open. 
