### PR TITLE
Fix glitch when there are multiple videos

### DIFF
--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -40,6 +40,7 @@
               v-else
               ref="video"
               controls
+              :key="media[select].sources[0].src"
               :width="media[select].width"
               :height="media[select].height"
               :autoplay="media[select].autoplay"


### PR DESCRIPTION
Key property was added to the video tag in order to re-render when switching between videos.