### PR TITLE
Add disableZoom option to enable users to zoom lightbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ How to use:
       <td>true</td>
       <td>set to `true` to avoid scrolling views behind lightbox</td>
     </tr>
+     <td>disableZoom</td>
+      <td>Boolean</td>
+      <td>true</td>
+      <td>set to `true` to avoid zooming lightbox</td>
+    </tr>
     <tr>
       <td>lengthToLoadMore</td>
       <td>Number</td>

--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -75,8 +75,8 @@
             <div class="vue-lb-footer">
               <div class="vue-lb-footer-info" />
               <div
-                class="vue-lb-footer-count"
                 v-show="showFooterCount"
+                class="vue-lb-footer-count"
               >
                 <slot
                   name="footer"
@@ -190,6 +190,11 @@ export default {
     },
 
     disableScroll: {
+      type: Boolean,
+      default: true,
+    },
+
+    disableZoom: {
       type: Boolean,
       default: true,
     },
@@ -358,8 +363,12 @@ export default {
     this.onToggleLightBox(this.lightBoxOn)
 
     if (this.$refs.container) {
-      const hammer = new Hammer(this.$refs.container)
+      const options = {}
+      if (!this.disableZoom) {
+        options.touchAction = 'pan-x, pan-y'
+      }
 
+      const hammer = new Hammer(this.$refs.container, options)
       hammer.on('swiperight', () => {
         this.previousImage()
       })


### PR DESCRIPTION
Users cannot zoom images in vue-image-lightbox because hammer.js blocks the events.
- https://hammerjs.github.io/touch-action/
- https://hammerjs.github.io/getting-started/#usage

This Pull Request adds `disableZoom` option to enable users to do it.

Taking backward compatibility into consideration, the default value of `disableZoom` is set to `true`


ref: https://github.com/pexea12/vue-image-lightbox/issues/78