### PR TITLE
New prop to be able to reset to the initial index if desired

### DIFF
--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -279,6 +279,11 @@ export default {
       type: String,
       default: 'Next',
     },
+
+    resetSelectedOnClose: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data() {
@@ -390,6 +395,10 @@ export default {
   methods: {
     onLightBoxOpen() {
       this.$emit('onOpened')
+
+      if(this.resetSelectedOnClose) {
+        this.select = this.startAt
+      }
 
       if (this.disableScroll) {
         document.querySelector('html').classList.add('no-scroll')


### PR DESCRIPTION
I have encountered a problem when trying to reduce the size of the image array dynamically (I want to do this so that when a color of a product is selected, a new image is added or removed to the array). The problem comes, when the last image that you have opened, is the last image of the array, so the property 'select' stays with the last index. But as I reduce the size of the array, 'select' points to an invalid index and stops working.

The simplest thing that has occurred to me is to create a property to reset if it is wanted to the initial index, and thus to avoid that if the size of the array of images is reduced, the exception does not jump.

Another possible solution would be to use a "watch" with the media array, and to reduce it if the size of the array is modified.

I have not been able to run it, because I have done it on a device where I have nothing installed apart from VS Code, but nothing should break.

Translated with www.DeepL.com/Translator (free version)