### PR TITLE
fix: change condition for media

### DIFF
--- a/src/components/LightBox.vue
+++ b/src/components/LightBox.vue
@@ -7,7 +7,7 @@
       @beforeLeave="disableImageTransition"
     >
       <div
-        v-if="media"
+        v-if="media && media.length > 0"
         v-show="lightBoxOn"
         ref="container"
         class="vue-lb-container"


### PR DESCRIPTION
In cases where we pass an empty array to props media => **Lightbox :media="[]"**, we get an error. This fix will fix this problem.
![error](https://user-images.githubusercontent.com/32683568/171993552-9b57925d-3c14-4a35-adca-2d10dffd4ec0.png)


